### PR TITLE
Revert "Ignore app properties"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,5 +223,8 @@ $RECYCLE.BIN/
 #För databas login
 *.env
 *.json
+application.properties
+.properties
+
 src/main/resources/application.properties
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,21 @@
+spring.application.name=GrannSnack
+# MySQL Connection Properties
+# Remote MySQL Connection Properties
+spring.datasource.url=jdbc:mysql://sql7.freesqldatabase.com:3306/sql7773037?useSSL=false&allowPublicKeyRetrieval=true
+spring.datasource.username=sql7773037
+spring.datasource.password=I8vi7J7I4U
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# Hibernate Properties
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
+# Connection Pool Properties with increased timeout for remote connections
+spring.datasource.hikari.connection-timeout=60000
+spring.datasource.hikari.maximum-pool-size=5
+
+# Hantera error sidor
+server.error.whitelabel.enabled=false
+server.error.path=/error
+


### PR DESCRIPTION
We decided to revert because the application.properties file had disappeared completely from working tree